### PR TITLE
copy over original crash/hang on tmin failure.

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -256,7 +256,8 @@ jobs:
           afl-cmin \
               -i corpus/ \
               -o fuzz-cmin/ \
-              -t 1000 \
+              -t 1000+ \
+              -m 3500 \
               -T all \
               -- ./${{ env.fuzzer-exe }}.afl
 
@@ -327,11 +328,14 @@ jobs:
           ls | shuf | head -n $MAX_TMIN | timeout 3600 parallel \
             --memfree 1G \
             --memsuspend 2G \
-            afl-tmin \
+            '{ afl-tmin \
                 -i {} \
                 -o ../fuzz-out/main/crashes/{} \
+                -t 1000+ \
+                -m 3500 \
                 -- ../${{ env.fuzzer-exe }}.afl \
-            || true
+            || cp {} ../fuzz-out/main/crashes/{}; }' \
+          || true
 
       - name: minimize hangs
         continue-on-error: true
@@ -347,12 +351,15 @@ jobs:
           ls | shuf | head -n $MAX_TMIN | timeout 3600 parallel \
             --memfree 1G \
             --memsuspend 2G \
-            afl-tmin \
+            '{ afl-tmin \
                 -i {} \
                 -o ../fuzz-out/main/hangs/{} \
+                -t 1000+ \
+                -m 3500 \
                 -H \
                 -- ../${{ env.fuzzer-exe }}.afl \
-            || true
+            || cp {} ../fuzz-out/main/hangs/{}; }' \
+          || true
 
       - name: list failures
         run: |


### PR DESCRIPTION
This ensures we don't just skip reporting failures due to tmin errors. Also, update tmin and cmin to have the same args are real fuzzing.

Fixes #10 