### PR TITLE
Avoid README in crash folder

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -155,6 +155,8 @@ jobs:
           # This avoids waiting for like 30+ min to start fuzzing canonicalize.
           # Might be better to restrict the input corpus somehow to be faster.
           AFL_FAST_CAL: 1
+          # Avoid generating a README that the rest of this script would view as a crash.
+          AFL_NO_CRASH_README: 1
         run: |
           # Initialize max memory tracking
           MAX_MEMORY_MB=0


### PR DESCRIPTION
This surprisingly has not been a problem until just now. We got a bad parse crash due to this. Basically:
1. Generate README in crash folder with other crashes.
2. Minimize everything (including the README, just does nothing).
3. README happens to be the shortest repro.
4. We upload the shortest repro.

Fixes #13 